### PR TITLE
Code cleanup, support for RN 0.33

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-azure-ad",
   "version": "0.1.0",
   "description": "A Azure AD authentication library implementation uses pure react native API (no native library needed).",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/ADLoginView.js
+++ b/src/ADLoginView.js
@@ -1,5 +1,6 @@
 // @flow
-import React, {WebView, Dimensions, AsyncStorage, Platform} from 'react-native'
+import React, {Component};
+import {WebView, Dimensions, AsyncStorage, Platform} from 'react-native'
 import CONST from './const.js'
 import ReactNativeAD from './ReactNativeAD.js'
 import Timer from 'react-timer-mixin'
@@ -8,7 +9,7 @@ import log from './logger'
 const loginUrl = 'https://login.microsoftonline.com/<tenant id>/oauth2/authorize'
 const tokenUrl = 'https://login.microsoftonline.com/common/oauth2/token'
 
-export default class ADLoginView extends React.Component {
+export default class ADLoginView extends Component {
 
   props : {
     onSuccess? : ?Function,

--- a/src/ReactNativeAD.js
+++ b/src/ReactNativeAD.js
@@ -7,6 +7,8 @@ import log from './logger'
 const loginUrl = 'https://login.microsoftonline.com/<tenant id>/oauth2/authorize'
 const tokenUrl = 'https://login.microsoftonline.com/common/oauth2/token'
 
+import type {ADConfig, ADCredentials, GrantTokenResp, ReactNativeADConfig, ReactNativeADCredential} from './types';
+
 /**
  * Global static hash map which stores contexts of different ReactNativeAD context,
  * which hash key is  {ReactNativeAD.config#client_id}

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
 //@flow
 
-declare type ADConfig = {
+export type ADConfig = {
   client_secret : string | null,
   client_id : string | null,
   redirect_uri : string | null,
@@ -8,16 +8,16 @@ declare type ADConfig = {
   resources : Array<string> | null,
 };
 
-declare type ADCredentials = {
+export type ADCredentials = {
   [key:string] : ReactNativeADCredential | null
 }
 
-declare type GrantTokenResp = {
+export type GrantTokenResp = {
   resource : string,
   response : Object
 };
 
-declare type ReactNativeADConfig = {
+export type ReactNativeADConfig = {
   client_id : string,
   redirect_uri? : string,
   authority_host : string,
@@ -27,7 +27,7 @@ declare type ReactNativeADConfig = {
   onSuccess : Function,
 };
 
-declare type ReactNativeADCredential = {
+export type ReactNativeADCredential = {
   access_token : string,
   expires_in : number,
   expires_on : number,


### PR DESCRIPTION
- **Move ADLoginView to new RN Component API**  
  You import the Component class from `react` now, not `react-native`.
- **Move package.json to root**  
  package.json should always be in the package root, and allows users to import the package from git.
- **Import types.js file**  
  It's great that this file exists, but ReactNativeAD doesn't actually use any of them because they're not being imported. (and as such, remove all flow capabilities)  
- **Initialize flow**  
  Flow can't be ran without a .flowconfig
