### PR TITLE
Token uri fix

### DIFF
--- a/src/ReactNativeAD.js
+++ b/src/ReactNativeAD.js
@@ -51,8 +51,8 @@ export default class ReactNativeAD {
       throw new Error('Invalid ADConfig object', config)
     if(typeof config.client_id !== 'string')
       throw new Error('client_id is not provided.')    
-    if (config.token != null)
-        config.token_uri = defaultTokenUrl.replace('common', config.token)
+    if (config.tenant != null)
+        config.token_uri = defaultTokenUrl.replace('common', config.tenant)
     this.config = config
     this.credentials = {}
     _contexts[config.client_id] = this

--- a/src/ReactNativeAD.js
+++ b/src/ReactNativeAD.js
@@ -50,7 +50,9 @@ export default class ReactNativeAD {
     if(config === null || config === void 0)
       throw new Error('Invalid ADConfig object', config)
     if(typeof config.client_id !== 'string')
-      throw new Error('client_id is not provided.')
+      throw new Error('client_id is not provided.')    
+    if (config.token != null)
+        config.token_uri = defaultTokenUrl.replace('common', config.token)
     this.config = config
     this.credentials = {}
     _contexts[config.client_id] = this

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ export type ADConfig = {
   tenant : string | null,
   prompt : string | null,
   resources : Array<string> | null,
+  token_uri: string | null
 };
 
 export type ADCredentials = {


### PR DESCRIPTION
// Line breaks for legibility only

POST /{tenant}/oauth2/token HTTP/1.1
Host: https://login.microsoftonline.com
Content-Type: application/x-www-form-urlencoded

The {tenant} value in the path of the request can be used to control who can sign into the application. The allowed values are tenant identifiers, for example, 8eaef023-2b34-4da1-9baa-8bc8c9d6a490 or contoso.onmicrosoft.com or common for tenant-independent tokens

reference: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code