### PR TITLE
Forward userAgent to webview 

### DIFF
--- a/src/ADLoginView.js
+++ b/src/ADLoginView.js
@@ -19,6 +19,7 @@ export default class ADLoginView extends React.Component {
     onURLChange : Function,
     context : ReactNativeAD,
     hideAfterLogin? : bool,
+    userAgent?: string
   };
 
   state : {
@@ -107,6 +108,7 @@ export default class ADLoginView extends React.Component {
           onShouldStartLoadWithRequest={(e) => {
             return true
           }}
+          userAgent={this.props.userAgent}
           renderError={() => renderError(this.refs.ADLoginView.reload)}
           startInLoadingState={false}
           injectedJavaScript={js}


### PR DESCRIPTION
In some cases Intune will refuse to generate a valid token for some APIs if it detects a mobile user agent string on login. Switching it to a destkop UA makes it work.