### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-azure-ad",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A Azure AD authentication library implementation uses pure react native API (no native library needed).",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Version hasn't changed for 2 years. Several changes have taken place since then, including changes to support new Azure AD changes. This allows for people pulling the package through npm to get these changes